### PR TITLE
fix: streaming source name extraction

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -1,8 +1,8 @@
 version: 3
 
 vars:
-  DOCKER_REGISTRY: '{{ default "docker.io" .DOCKER_REGISTRY  }}'
-  DOCKER_IMAGE: '{{ default "prometheus-exporter" .DOCKER_IMAGE }}'
+  DOCKER_REGISTRY: '{{ default "eu.gcr.io/contiamo-public/" .DOCKER_REGISTRY  }}'
+  DOCKER_IMAGE: '{{ default "spark-prometheus-export" .DOCKER_IMAGE }}'
   DOCKER_TAG: '{{ default "latest" .DOCKER_TAG  }}'
 
 tasks:
@@ -38,7 +38,7 @@ tasks:
   docker:build:
     desc: build the docker image
     cmds:
-      - docker build --target=distribution -t {{.DOCKER_IMAGE}}-dist:{{.DOCKER_TAG}} .
+      - docker build --target=distribution -t {{.DOCKER_REGISTRY}}{{.DOCKER_IMAGE}}-dist:{{.DOCKER_TAG}} .
 
   distribute:
     deps:

--- a/prometheus-export/src/main/scala/StreamingQuerySource.scala
+++ b/prometheus-export/src/main/scala/StreamingQuerySource.scala
@@ -67,8 +67,16 @@ object StreamingQuerySource {
   def getOffset(
       offsetJSON: String
   ): Map[String, Map[String, Long]] = {
-    implicit val formats = DefaultFormats
-    parse(offsetJSON).extract[Map[String, Map[String, Long]]]
+    if (offsetJSON == null || offsetJSON == "") {
+      return Map()
+    }
+
+    offsetJSON.trim.headOption match {
+      case Some('{') if offsetJSON.trim.lastOption.contains('}') =>
+        implicit val formats = DefaultFormats
+        parse(offsetJSON).extract[Map[String, Map[String, Long]]]
+      case _ => Map()
+    }
   }
 
 }

--- a/prometheus-export/src/main/scala/StreamingQuerySource.scala
+++ b/prometheus-export/src/main/scala/StreamingQuerySource.scala
@@ -33,8 +33,12 @@ object StreamingQuerySource {
     value.split("\\[").last.split("\\]").head
   }
 
+  /**
+    * extract the source name from the description for example
+    * "KafkaV2[Subscribe[mpathic-event]]" becomes "KafkaV2"
+    */
   def extractSourceName(value: String): String = {
-    value.split("\\[", 1).head
+    value.split("\\[").head
   }
 
   // An offset object is a json field with a map of topics to a map of partitions to offsets

--- a/prometheus-export/src/test/scala/StreamingQuerySourceTest.scala
+++ b/prometheus-export/src/test/scala/StreamingQuerySourceTest.scala
@@ -1,0 +1,89 @@
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.apache.spark.metrics.source.StreamingQuerySource
+
+class StreamingQuerySourceSpec extends AnyFlatSpec with Matchers {
+"metricWithLabels" should "return the metric name with labels" in {
+    val name = "my_metric"
+    val labels = Map("foo" -> "bar", "baz" -> "qux")
+    val expectedOutput = "my_metric.LABELS.foo.bar.baz.qux"
+    val actualOutput = StreamingQuerySource.metricWithLabels(name, labels)
+    actualOutput shouldEqual expectedOutput
+  }
+
+  "metricWithLabels" should "return the metric name without labels if the labels map is empty" in {
+    val name = "my_metric"
+    val labels = Map.empty[String, String]
+    val expectedOutput = "my_metric"
+    val actualOutput = StreamingQuerySource.metricWithLabels(name, labels)
+    actualOutput shouldEqual expectedOutput
+  }
+
+  "extractSourceName" should "return the source name from a string" in {
+    val input = "KafkaV2[Subscribe[mpathic-event]]"
+    val expectedOutput = "KafkaV2"
+    val actualOutput = StreamingQuerySource.extractSourceName(input)
+    actualOutput shouldEqual expectedOutput
+  }
+
+  "extractSubscriptionName" should "return the kafka topic from the description" in {
+    val input = "KafkaV2[Subscribe[mpathic-event]]"
+    val expectedOutput = "mpathic-event"
+    val actualOutput = StreamingQuerySource.extractSubscriptionName(input)
+    actualOutput shouldEqual expectedOutput
+  }
+
+  "getOffset" should "parse a valid offset JSON string into a map of topics to partitions to offsets" in {
+    val input = """{
+      "mpathic-event": {
+          "0": 689125037,
+          "1": 597416917,
+          "2": 589446933,
+          "3": 444659423,
+          "4": 432998635,
+          "5": 429711474,
+          "6": 445322191,
+          "7": 432412809,
+          "8": 431092969,
+          "9": 444619591
+      },
+      "topic2": {
+          "0": 689125037,
+          "1": 597416917,
+          "2": 589446933,
+          "3": 444659423,
+          "4": 432998635
+      }
+    }"""
+    val expectedOutput = Map(
+      "mpathic-event" -> Map(
+        "0" -> 689125037,
+        "1" -> 597416917,
+        "2" -> 589446933,
+        "3" -> 444659423,
+        "4" -> 432998635,
+        "5" -> 429711474,
+        "6" -> 445322191,
+        "7" -> 432412809,
+        "8" -> 431092969,
+        "9" -> 444619591
+      ),
+      "topic2" -> Map(
+        "0" -> 689125037,
+        "1" -> 597416917,
+        "2" -> 589446933,
+        "3" -> 444659423,
+        "4" -> 432998635
+      )
+    )
+    val actualOutput = StreamingQuerySource.getOffset(input)
+    actualOutput shouldEqual expectedOutput
+  }
+
+  "getOffset" should "parse a valid empty JSON into an empty map" in {
+    val input = "{}"
+    val expectedOutput = Map.empty[String, Map[String, Long]]
+    val actualOutput = StreamingQuerySource.getOffset(input)
+    actualOutput shouldEqual expectedOutput
+  }
+}

--- a/prometheus-export/src/test/scala/StreamingQuerySourceTest.scala
+++ b/prometheus-export/src/test/scala/StreamingQuerySourceTest.scala
@@ -86,4 +86,10 @@ class StreamingQuerySourceSpec extends AnyFlatSpec with Matchers {
     val actualOutput = StreamingQuerySource.getOffset(input)
     actualOutput shouldEqual expectedOutput
   }
+  "getOffset" should "return an empty map if the string is empty" in {
+    val input = ""
+    val expectedOutput = Map.empty[String, Map[String, Long]]
+    val actualOutput = StreamingQuerySource.getOffset(input)
+    actualOutput shouldEqual expectedOutput
+  }
 }


### PR DESCRIPTION
Fix a bug in the streaming source name parsing. The previous parsing left trailing brackets `[]` which then caused the kafka offset parsing to be skipped. These trailing brackets are no longer included.

Additionally, add unit tests for several of the helper methods.

When testing this in our spark project, we now get the expected offset metrics 

```
# TYPE metrics_driver_StreamingQuerySource_streaming_batch_num_input_rows gauge
metrics_driver_StreamingQuerySource_streaming_batch_num_input_rows{name="loader"} 2.0

# TYPE metrics_driver_StreamingQuerySource_streaming_source_kafka_partition_offset gauge
metrics_driver_StreamingQuerySource_streaming_source_kafka_partition_offset{name="loader",topic="test_topic",partition="0",offset_type="startOffset"} 15.0
metrics_driver_StreamingQuerySource_streaming_source_kafka_partition_offset{name="loader",topic="test_topic",partition="0",offset_type="latestOffset"} 17.0
metrics_driver_StreamingQuerySource_streaming_source_kafka_partition_offset{name="loader",topic="test_topic",partition="0",offset_type="endOffset"} 17.0

# TYPE metrics_driver_StreamingQuerySource_streaming_source_kafka_rows summary
metrics_driver_StreamingQuerySource_streaming_source_kafka_rows_count{name="loader",subscription="test_topic",source="KafkaV2"} 6
metrics_driver_StreamingQuerySource_streaming_source_kafka_rows_sum{name="loader",subscription="test_topic",source="KafkaV2"} 8
metrics_driver_StreamingQuerySource_streaming_source_kafka_rows{name="loader",subscription="test_topic",source="KafkaV2",quantile="0.5"} 1.0
metrics_driver_StreamingQuerySource_streaming_source_kafka_rows{name="loader",subscription="test_topic",source="KafkaV2",quantile="0.75"} 2.0
metrics_driver_StreamingQuerySource_streaming_source_kafka_rows{name="loader",subscription="test_topic",source="KafkaV2",quantile="0.95"} 5.0
metrics_driver_StreamingQuerySource_streaming_source_kafka_rows{name="loader",subscription="test_topic",source="KafkaV2",quantile="0.98"} 5.0
metrics_driver_StreamingQuerySource_streaming_source_kafka_rows{name="loader",subscription="test_topic",source="KafkaV2",quantile="0.99"} 5.0
metrics_driver_StreamingQuerySource_streaming_source_kafka_rows{name="loader",subscription="test_topic",source="KafkaV2",quantile="0.999"} 5.0
```