### PR TITLE
feat: support iceberg offset parsing

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Build Image
         run: docker build -t ${DOCKER_REGISTRY}:${GITHUB_REF_NAME} .
       - name: Log Into Registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: _json_key
           password: ${{ secrets.GCR_JSON_KEY }}

--- a/prometheus-export/src/main/scala/StreamingQuerySource.scala
+++ b/prometheus-export/src/main/scala/StreamingQuerySource.scala
@@ -123,8 +123,8 @@ object StreamingQuerySource extends Logging {
       }
     } else {
       Map()
+    }
   }
-
 }
 
 class StreamingQuerySource() extends Source with Logging {

--- a/prometheus-export/src/test/scala/StreamingQuerySourceTest.scala
+++ b/prometheus-export/src/test/scala/StreamingQuerySourceTest.scala
@@ -19,7 +19,7 @@ class StreamingQuerySourceSpec extends AnyFlatSpec with Matchers {
     actualOutput shouldEqual expectedOutput
   }
 
-  "extractSourceName" should "return the Kafkfa source name from a string" in {
+  "extractSourceName" should "return the Kafka source name from a string" in {
     val input = "KafkaV2[Subscribe[mpathic-event]]"
     val expectedOutput = "KafkaV2"
     val actualOutput = StreamingQuerySource.extractSourceName(input)

--- a/prometheus-export/src/test/scala/StreamingQuerySourceTest.scala
+++ b/prometheus-export/src/test/scala/StreamingQuerySourceTest.scala
@@ -19,9 +19,16 @@ class StreamingQuerySourceSpec extends AnyFlatSpec with Matchers {
     actualOutput shouldEqual expectedOutput
   }
 
-  "extractSourceName" should "return the source name from a string" in {
+  "extractSourceName" should "return the Kafkfa source name from a string" in {
     val input = "KafkaV2[Subscribe[mpathic-event]]"
     val expectedOutput = "KafkaV2"
+    val actualOutput = StreamingQuerySource.extractSourceName(input)
+    actualOutput shouldEqual expectedOutput
+  }
+
+  "extractSourceName" should "return the Iceberg source name from a string" in {
+    val input = "org.apache.iceberg.spark.source.SparkMicroBatchStream@32c41681"
+    val expectedOutput = "IcebergMicroBatchStream"
     val actualOutput = StreamingQuerySource.extractSourceName(input)
     actualOutput shouldEqual expectedOutput
   }


### PR DESCRIPTION
Add the ability to parse snapshot_id offsets from iceberg streams. 

Also add `reportGauge` and `reportHistogram` overrides so that they can be accessed from pyspark.

Example pyspark usage

```python
from typing import Any, Dict, Protocol

from pyspark.sql import SparkSession


class MetricsSource(Protocol):
    def start(self):
        pass

    def reportGauge(self, name: str, labels: Dict[str, str], value: int):
        pass

    def reportHistogram(self, name: str, labels: Dict[str, str], value: int):
        pass


def start_streaming_metrics(spark: SparkSession) -> MetricsSource:
    """Register and start the streaming metrics source"""
    source: MetricsSource = (
        spark.sparkContext._gateway.jvm.org.apache.spark.metrics.source.StreamingQuerySource()  # type: ignore
    )
    register_source(spark, source)
    source.start()

    return source

```

then in your streaming query 

```python

def process_batch(metrics: MetricsSource):
    def process(df: DataFrame, id: int):
        if df.isEmpty():
            return
        
        # get the max loaded_at as a unix timestamp in milliseconds
        try:
            max_loaded_at: datetime = df.agg(F.max(F.col("loaded_at"))).collect()[0][0]
            max_loaded_at_ms = int(max_loaded_at.timestamp() * 1000)
            metrics.reportGauge(
                "streaming.batch.events_highwatermark_ms", 
                {"query_name": "our_streaming_query"},
                max_loaded_at_ms
            )
        except Exception as e:
            logger.error(f"Error getting max loaded_at: {e}")



def main():
  # other setup here to create the dataframe df
  metrics = start_streaming_metrics(spark)
  stream = (
          df
          .writeStream.queryName("base_events_loader")
          .trigger(processingTime="1 minute")
          .option("checkpointLocation", opts.checkpoint_location)
          .foreachBatch(process_batch(metricsSource))
          .start()
      )
```